### PR TITLE
Expose error name for MessageBus.invoke() errors

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -137,7 +137,7 @@ module.exports = function bus(conn, opts) {
           args = [null].concat(args); // first argument - no errors, null
           handler.apply(props, args); // body as array of arguments
         } else {
-          handler.call(props, args); // body as first argument
+          handler.call(props, {name: msg.errorName, message: args}); // body as first argument
         }
       }
     } else if (msg.type === constants.messageType.signal) {


### PR DESCRIPTION
## :recycle: Current situation

`MessageBus.invoke()` takes a callback, the first argument of which is the error encountered, if any, and the remaining arguments are the return arguments of the D-Bus method call. Per [the D-Bus spec][spec], messages of type `ERROR` are described as follows:

> Error reply. If the first argument exists and is a string, it is an error message.

Additionally, these messages must have an `ERROR_NAME` header field, which is a string that indicates the type of error they represent.

Currently, if an error occurs, `MessageBus.invoke()` passes the return arguments, and not the error name, to the callback. The upshot of this is that the callback receives only the user-friendly explanation of what went wrong, not the machine-usable error type.

## :bulb: Proposed solution

This changes the behavior of `MessageBus.invoke()` to, when an error occurs, invoke the callback passing as the first argument an object that looks like this:
```javascript
{
  name: "ERROR_NAME",
  message: "what used to be passed in as the first argument"
}
```

## :gear: Release Notes

- **Breaking change**: When an error occurs in `MessageBus.invoke()` or `MessageBus.invokeDbus()`, the first argument passed to the callback (err) is now an object containing two keys: `name` is the D-Bus error name, and `message` is what previously was passed in as this argument.

## :heavy_plus_sign: Additional Information

See https://github.com/homebridge/HAP-NodeJS/issues/980#issuecomment-1299400854

[spec]: https://dbus.freedesktop.org/doc/dbus-specification.html