### PR TITLE
Include TypeScript type definitions and publish to npm

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,21 @@
+import {EventEmitter} from 'events'
+import {Socket} from 'net'
+
+interface DbusInterface extends EventEmitter {
+	on(event: string, callback: (error: Error, data: any) => void): void
+}
+
+interface DbusService {
+	getInterface(path: string, interfaceName: string, callback: (error: Error, interface: DbusInterface) => void): void
+}
+
+interface DbusBus {
+	getService(serviceName: string): DbusService
+}
+
+function systemBus(): DbusBus
+function sessionBus(): DbusBus
+
+export {systemBus, sessionBus}
+export default {systemBus, sessionBus}
+

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "bin/dbus2js.js",
     "lib/*",
     "index.js",
-    "package.json"
+    "package.json",
+    "index.d.ts"
   ],
   "directories": {
     "lib": "lib",


### PR DESCRIPTION
This PR includes TypeScript type definitions which I grabbed from here: https://github.com/homebridge/HAP-NodeJS/blob/4a2009f2810a7cc2b476be0ee858b8e62d2ee4f2/src/types/dbus-native.d.ts

It also updates package.json to publish `index.d.ts` to npm so consumers of this package will receive the type definitions. 

We're currently using this fork with `npm install --save github:getumbrel/dbus-native#types` in @getumbrel and it's working well for us with types but we'd love to move back to this fork if this PR is accepted. Thanks!