### PR TITLE
Replace abstract-socket dep with Node.js builtin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Fork Status
 ------------
 
 This fork is maintained with the following changes:
-* Removed the optional `abstract-socket` dependency for faster installs
+* Raised minimum supported Node.js version to 20.8
+* Removed the `abstract-socket` dependency in favor of Node.js builtin support
 * Moved to our `long.js` fork to work around a crash on `ARMv6` platforms running node 16.1+
 * Updated dependencies (including `prettier`, which has made style changes to a lot of files)
 

--- a/bin/dbus-dissect.js
+++ b/bin/dbus-dissect.js
@@ -2,7 +2,6 @@
 // needs a lot of cleanup but does the job
 
 const net = require('net');
-const abs = require('abstract-socket');
 const through2 = require('through2');
 const minimist = require('minimist');
 const message = require('../lib/message');
@@ -35,8 +34,7 @@ net
     var buff = '';
     var connected = false;
 
-    var socket = isSystemBus ? net : abs;
-    var cli = socket.connect(address);
+    var cli = net.connect(address);
 
     s.on('data', function (d) {
       if (connected) {

--- a/bin/package-lock.json
+++ b/bin/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "bin",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "through2": "^4.0.2"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "3"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    }
+  }
+}

--- a/bin/package.json
+++ b/bin/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "through2": "^4.0.2"
+  }
+}

--- a/index.js
+++ b/index.js
@@ -40,10 +40,8 @@ function createStream(opts) {
           return net.createConnection(port, host);
         case 'unix':
           if (params.socket) return net.createConnection(params.socket);
-          if (params.abstract) {
-            var abs = require('abstract-socket');
-            return abs.connect('\u0000' + params.abstract);
-          }
+          if (params.abstract)
+            return net.createConnection('\0' + params.abstract);
           if (params.path) return net.createConnection(params.path);
           throw new Error(
             "not enough parameters for 'unix' connection - you need to specify 'socket' or 'abstract' or 'path' parameter"

--- a/lib/portforward.js
+++ b/lib/portforward.js
@@ -1,5 +1,4 @@
 const net = require('net');
-const abs = require('abstract-socket');
 const hexy = require('hexy').hexy;
 
 var address = process.env.DBUS_SESSION_BUS_ADDRESS;
@@ -9,7 +8,7 @@ net
   .createServer(function (s) {
     var buff = '';
     var connected = false;
-    var cli = abs.createConnection(`\0${m[1]}`);
+    var cli = net.createConnection(`\0${m[1]}`);
     s.on('data', function (d) {
       if (connected) {
         cli.write(d);

--- a/package.json
+++ b/package.json
@@ -46,11 +46,6 @@
     "safe-buffer": "^5.1.2",
     "xml2js": "^0.6.2"
   },
-  "comment": {
-    "optionalDependencies": {
-      "abstract-socket": "^2.0.0"
-    }
-  },
   "devDependencies": {
     "@types/minimist": "^1.2.5",
     "eslint": "^8.57.1",
@@ -87,6 +82,6 @@
     "trailingComma": "none"
   },
   "engine": {
-    "node": ">=8.0"
+    "node": ">=20.8"
   }
 }

--- a/test/utils/packetcapture.js
+++ b/test/utils/packetcapture.js
@@ -1,6 +1,5 @@
 const Buffer = require('safe-buffer').Buffer;
 const net = require('net');
-const abs = require('abstract-socket');
 const hexy = require('hexy').hexy;
 const buffs = require('buffers');
 const fs = require('fs');
@@ -26,7 +25,7 @@ net
     var buff = '';
     var b = buffs();
     var connected = false;
-    var cli = abs.createConnection('\0/tmp/dbus-WDSwP4V64O');
+    var cli = net.createConnection('\0/tmp/dbus-WDSwP4V64O');
     s.on('data', function (d) {
       if (connected) {
         cli.write(d);

--- a/test/utils/portforv.js
+++ b/test/utils/portforv.js
@@ -1,5 +1,4 @@
 const net = require('net');
-const abs = require('abstract-socket');
 const hexy = require('hexy').hexy;
 
 net
@@ -7,7 +6,7 @@ net
     console.log('connection!');
     var buff = '';
     var connected = false;
-    var cli = abs.createConnection('\0/tmp/dbus-0PpuqHgmcw');
+    var cli = net.createConnection('\0/tmp/dbus-0PpuqHgmcw');
     s.on('data', function (d) {
       console.log('');
       var len = d.length;


### PR DESCRIPTION
## :recycle: Current situation

`abstract-socket` was removed but not replaced.

## :bulb: Proposed solution

Node.js >= 20.8 has builtin support for abstract sockets.

## :gear: Release Notes

* Raised minimum supported Node.js version to 20.8
* Removed the `abstract-socket` dependency in favor of Node.js builtin support

## :heavy_plus_sign: Additional Information

_If applicable, provide additional context in this section._

### Testing

_Which tests were added? Which existing tests were adapted/changed? Which situations are covered, and what edge cases are missing?_

### Reviewer Nudging

_Where should the reviewer start? what is a good entry point?_
