### PR TITLE
fix: preserve D-Bus error details instead of printing [object Object]

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -235,7 +235,7 @@ module.exports = function bus(conn, opts) {
   // register name
   if (opts.direct !== true) {
     this.invokeDbus({ member: 'Hello' }, function (err, name) {
-      if (err) throw new Error(err);
+      if (err) throw new Error((err.name || 'Error') + ': ' + (err.message || err));
       self.name = name;
     });
   } else {


### PR DESCRIPTION
When a D-Bus error response arrives, `err` is an object with `.name` and `.message` properties. Wrapping it in `new Error(err)` called `.toString()` on it, producing `[object Object]` and hiding the actual D-Bus error.

**Before:**
```
Error: [object Object]
    at Object.<anonymous> (.../bus.js:238:22)
```
No way to tell what went wrong.

**After:**
```
Error: org.freedesktop.DBus.Error.AccessDenied: An AppArmor policy prevents this sender from sending this message to this recipient; type="method_call", sender="(null)" (inactive) interface="org.freedesktop.DBus" member="Hello" error name="(unset)" requested_reply="0" destination="org.freedesktop.DBus" (bus)
    at Object.<anonymous> (.../bus.js:238:21)
```
The actual D-Bus error is preserved, making it debuggable.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>